### PR TITLE
Make cesiumBaseUrl absolute

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,15 +3,15 @@ import { viteStaticCopy } from "vite-plugin-static-copy";
 
 const cesiumSource = "node_modules/cesium/Build/Cesium";
 // This is the base url for static files that CesiumJS needs to load.
-// Set to "/" to place the files at the site's root path
-const cesiumBaseUrl = "/cesiumStatic";
+// Set to an empty string to place the files at the site's root path
+const cesiumBaseUrl = "cesiumStatic";
 
 // https://vitejs.dev/config/
 export default defineConfig({
   define: {
     // Define relative base path in cesium for loading assets
     // https://vitejs.dev/config/shared-options.html#define
-    CESIUM_BASE_URL: JSON.stringify(cesiumBaseUrl),
+    CESIUM_BASE_URL: JSON.stringify(`/${cesiumBaseUrl}`),
   },
   plugins: [
     // Copy Cesium Assets, Widgets, and Workers to a static directory.

--- a/vite.config.js
+++ b/vite.config.js
@@ -3,8 +3,8 @@ import { viteStaticCopy } from "vite-plugin-static-copy";
 
 const cesiumSource = "node_modules/cesium/Build/Cesium";
 // This is the base url for static files that CesiumJS needs to load.
-// Set to an empty string to place the files at the site's root path
-const cesiumBaseUrl = "cesiumStatic";
+// Set to "/" to place the files at the site's root path
+const cesiumBaseUrl = "/cesiumStatic";
 
 // https://vitejs.dev/config/
 export default defineConfig({


### PR DESCRIPTION
Should fix issue #4

To show that this is necessary, I made a branch on my fork called multipage-example. Check it out, and remove the / in `cesiumBaseUrl` in vite.config.js. After starting the dev server, try accessing the second page at `localhost:{port}/multipage`.